### PR TITLE
GrinningScoreのバグ修正

### DIFF
--- a/src/components/molecules/faceRecognition.tsx
+++ b/src/components/molecules/faceRecognition.tsx
@@ -40,7 +40,12 @@ const FaceRecognition: FC<FaceRecognitionProps> = memo(
   ({ movieDetailRef, movie }) => {
     const { moviePlayerState } = useContext(CoreFunctionsContext);
 
-    const { grinningScore, setGrinningScore } = useContext(AppContext);
+    const {
+      grinningScore,
+      setGrinningScore,
+      grinningScoreOnPause,
+      setGrinningScoreOnPause,
+    } = useContext(AppContext);
     const webcamRef = useRef<HTMLVideoElement>(null);
     const [isModelReady, setIsModelReady] = useState<boolean>(false);
     const [isWebcamReady, setIsWebcamReady] = useState<boolean>(false);
@@ -74,6 +79,7 @@ const FaceRecognition: FC<FaceRecognitionProps> = memo(
             if (value > THRESHOLD && key == 'happy') {
               setBatchScore(batchScore + 1);
               setGrinningScore(grinningScore + 1);
+              setGrinningScoreOnPause(grinningScoreOnPause + 1);
             }
           }
         }
@@ -83,6 +89,7 @@ const FaceRecognition: FC<FaceRecognitionProps> = memo(
             grinningScore: grinningScore,
             movieId: movie.movieId,
           });
+          setGrinningScoreOnPause(0);
           setBatchIter(0);
           setBatchScore(0);
           return;

--- a/src/components/molecules/youTubePlayer.tsx
+++ b/src/components/molecules/youTubePlayer.tsx
@@ -21,7 +21,7 @@ type YouTubePlayerProps = {
 /* eslint-disable react/display-name */
 const YouTubePlayer: FC<YouTubePlayerProps> = memo(({ movie }) => {
   const { setMoviePlayerState } = useContext(CoreFunctionsContext);
-  const { grinningScore } = useContext(AppContext);
+  const { grinningScore, grinningScoreOnPause } = useContext(AppContext);
 
   const [isOverviewOpened, setIsOverviewOpened] = useState<boolean>(false);
   const { overview, title, createdAt, username } = movie;
@@ -123,10 +123,10 @@ const YouTubePlayer: FC<YouTubePlayerProps> = memo(({ movie }) => {
 
   const handleSendScoreOnPause = useCallback(() => {
     handleSendScore({
-      grinningScore: grinningScore,
+      grinningScore: grinningScoreOnPause,
       movieId: movie.movieId,
     });
-  }, [grinningScore, movie.movieId]);
+  }, [grinningScoreOnPause, movie.movieId]);
 
   return (
     <Box sx={styles.box}>

--- a/src/components/templates/movieDetailTemplate.tsx
+++ b/src/components/templates/movieDetailTemplate.tsx
@@ -2,11 +2,11 @@ import React, { FC, memo, useRef } from 'react';
 import { MuiDivider } from 'components/atoms/divider';
 import { MovieListTitle } from 'components/atoms/texts';
 import { MovieList } from 'components/organisms/movieList';
-import { Box, useMediaQuery } from '@mui/material';
+import { Box } from '@mui/material';
 import { Movie } from 'types/dataTypes';
 import { Bar } from 'components/organisms';
 import { PlayerCoreFunctions } from 'components/organisms/playerCoreFunctions';
-import { BasePixel, ScreenSize } from 'components/constants';
+import { BasePixel } from 'components/constants';
 import { FlexBox } from 'components/atoms/layoutElement';
 
 type Props = {

--- a/src/contexts/appContext.tsx
+++ b/src/contexts/appContext.tsx
@@ -54,6 +54,7 @@ const AppProvider: FC = ({ children }) => {
   const [randomMovie, setRandomMovie] = useState<Maybe<Movie>>(null);
   const [searchInput, setSearchInput] = useState<string>('');
   const [grinningScore, setGrinningScore] = useState<number>(0);
+  // The score to send when paused
   const [grinningScoreOnPause, setGrinningScoreOnPause] = useState<number>(0);
 
   return (

--- a/src/contexts/appContext.tsx
+++ b/src/contexts/appContext.tsx
@@ -25,6 +25,8 @@ type AppState = {
   setSearchInput: (input: string) => void;
   grinningScore: number;
   setGrinningScore: (input: number) => void;
+  grinningScoreOnPause: number;
+  setGrinningScoreOnPause: (input: number) => void;
 };
 
 export const AppContext = createContext({} as AppState);
@@ -52,6 +54,7 @@ const AppProvider: FC = ({ children }) => {
   const [randomMovie, setRandomMovie] = useState<Maybe<Movie>>(null);
   const [searchInput, setSearchInput] = useState<string>('');
   const [grinningScore, setGrinningScore] = useState<number>(0);
+  const [grinningScoreOnPause, setGrinningScoreOnPause] = useState<number>(0);
 
   return (
     <AppContext.Provider
@@ -76,6 +79,8 @@ const AppProvider: FC = ({ children }) => {
         searchInput: searchInput,
         grinningScore: grinningScore,
         setGrinningScore: setGrinningScore,
+        grinningScoreOnPause: grinningScoreOnPause,
+        setGrinningScoreOnPause: setGrinningScoreOnPause,
       }}
     >
       {children}


### PR DESCRIPTION
- 背景：10秒ごとに`grinningScore`を送信していたが、ビデオ停止時に同じ`grinningScore`の値を送信していたため正しいスコアが送信されていなかった。（ex: 再生開始10秒後に5を送り、その後動画を停止するとさらに5を送信してしまっていた）
- 変更点：`grinningScoreOnPause`という`state`を使用し、停止時は「あなたのニヤッと回数」と`grinningScore`の差分を送るように変更